### PR TITLE
added set_current_session method

### DIFF
--- a/gaesessions/__init__.py
+++ b/gaesessions/__init__.py
@@ -34,6 +34,19 @@ def get_current_session():
     """Returns the session associated with the current request."""
     return _current_session
 
+def set_current_session(session=None, **kwds):
+    """Sets the _current_session global so the session is automanaged."""
+    global _current_session    
+
+    if not session:
+        _current_session = Session(**kwds)
+    elif isinstance(session, basestring):
+        _current_session = Session(sid=session, **kwds)
+    elif isinstance(session, Session):
+        _current_session = session
+        
+    return _current_session
+    
 def is_gaesessions_key(k):
     return k.startswith(COOKIE_NAME_PREFIX)
 


### PR DESCRIPTION
added set_current_session for situations where you manually create a session object and want it to be auto-managed by the middleware.

for a while I was going crazy trying to figure out why the Session object I was creating was not getting stored at the end of the request, like other sessions.  Then I realized that only _current_session gets stored at the end of the request.

I needed this because I'm using a client that doesn't send a cookie, but does send a session id.
