### PR TITLE
allow pip installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,11 @@
+from setuptools import setup
+setup(name='gaesessions',
+      version='1.0.7',
+      author='David Underhill',
+      author_email='',
+      license='Apache License Version 2.0',
+      description='gae-sessions is a sessions library for the Python runtime on Google App Engine for ALL session sizes. ' +
+      'It is extremely fast, lightweight (one file), and easy to use.',
+      py_modules=['gaesessions'],
+      install_requires=[
+      ])

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,6 @@ setup(name='gaesessions',
       license='Apache License Version 2.0',
       description='gae-sessions is a sessions library for the Python runtime on Google App Engine for ALL session sizes. ' +
       'It is extremely fast, lightweight (one file), and easy to use.',
-      py_modules=['gaesessions'],
+      py_modules=['gaesessions.__init__'],
       install_requires=[
       ])


### PR DESCRIPTION
I had some troubles using webapp2_extras session with ferris3 and found gae-sessions. It's great for my purposes. 

I'm using pip and a requirements.txt to keep other python modules up to date. Please add a setup.py, so it can be installed even easier.

i.e.:
requirements.txt:

```
git+https://github.com/dound/gae-sessions.git#egg=gaesessions
```

installation to the lib folder:

```
pip install -r requirements.txt -t lib/
```

This pull request is an example of how the setup.py could look like.
